### PR TITLE
fix for jira CLUS-4103: using incorrect password field for admin user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAMESPACE=severalnines
 NAME=clustercontrol
 BINARY=terraform-provider-${NAME}
 TARGET=./bin/${BINARY}
-VERSION=0.2.17
+VERSION=0.2.18
 OS_ARCH=darwin_amd64
 TARGET_DIR=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 

--- a/internal/provider/db_cluster_common.go
+++ b/internal/provider/db_cluster_common.go
@@ -63,7 +63,9 @@ func (c *DbCommon) GetInputs(d *schema.ResourceData, jobData *openapi.JobsJobJob
 	}
 
 	dbAdminUserPassword := d.Get(TF_FIELD_CLUSTER_ADMIN_PW).(string)
-	jobData.SetAdminPassword(dbAdminUserPassword)
+	// CLUS-4103
+	//jobData.SetAdminPassword(dbAdminUserPassword)
+	jobData.SetDbPassword(dbAdminUserPassword)
 
 	//var iPort int
 	//port := d.Get(TF_FIELD_CLUSTER_PORT).(string)


### PR DESCRIPTION
fix for jira CLUS-4103: using incorrect password field to set admin user's password.